### PR TITLE
Switched to Doctrine Inflector for String manipulation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": "~5.4",
         "psr/log": "~1.0",
-        "linio/util": "~1.0",
-        "mandrill/mandrill": "1.0.*"
+        "mandrill/mandrill": "1.0.*",
+        "doctrine/inflector": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*"

--- a/composer.lock
+++ b/composer.lock
@@ -1,47 +1,77 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d89cce5bdc67a59a1d0eb80851a1427f",
+    "hash": "ecf88ccebf454b5dc390ef0b3f910d6b",
     "packages": [
         {
-            "name": "linio/util",
-            "version": "1.0.0",
+            "name": "doctrine/inflector",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/LinioIT/util.git",
-                "reference": "ebc15b2b2de1e23578e7fe74fddcc291f200210d"
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "0bcb2e79d8571787f18b7eb036ed3d004908e604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/LinioIT/util/zipball/ebc15b2b2de1e23578e7fe74fddcc291f200210d",
-                "reference": "ebc15b2b2de1e23578e7fe74fddcc291f200210d",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/0bcb2e79d8571787f18b7eb036ed3d004908e604",
+                "reference": "0bcb2e79d8571787f18b7eb036ed3d004908e604",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.4"
+                "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.5.*"
+                "phpunit/phpunit": "4.*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-4": {
-                    "Linio\\Component\\Util\\": "src"
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
-            "description": "Generic component that provides many helper classes, such as JSON parsing, conversion tools, data structures, etc.",
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
             "keywords": [
-                "linio",
-                "util"
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
             ],
-            "time": "2015-03-16 16:31:02"
+            "time": "2014-12-20 21:24:13"
         },
         {
             "name": "mandrill/mandrill",

--- a/src/AdapterFactory.php
+++ b/src/AdapterFactory.php
@@ -2,6 +2,7 @@
 
 namespace Linio\Component\Mail;
 
+use Doctrine\Common\Inflector\Inflector;
 use Linio\Component\Util\String;
 
 class AdapterFactory
@@ -13,7 +14,7 @@ class AdapterFactory
      */
     public function getAdapter($adapterName, $adapterConfig = array())
     {
-        $adapterClass = sprintf('%s\\Adapter\\%sAdapter', __NAMESPACE__, String::pascalize($adapterName));
+        $adapterClass = sprintf('%s\\Adapter\\%sAdapter', __NAMESPACE__, Inflector::classify($adapterName));
 
         if (!class_exists($adapterClass)) {
             throw new \InvalidArgumentException('Adapter class does not exist: ' . $adapterClass);


### PR DESCRIPTION
This was done as String is not allowed as a class name in PHP 7. We will be moving towards removing String from linio/util.
